### PR TITLE
Add new workflow for issue -> PR.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,36 @@
+name: Parse issue and create PR
+
+on:
+  issues:
+    types: ['opened']
+
+jobs:
+  parse-issue-and-create-pr:
+    runs-on: ubuntu-latest
+    name: Parse issue and commit into tweets folder
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Run Issue form parser
+      uses: stefanbuck/github-issue-parser@v2
+      id: issue-parser
+      with:
+        template-path: .github/ISSUE_TEMPLATE/new-tweet-request.yaml
+    - run: |
+        echo '${{ steps.issue-parser.outputs.jsonString }}' > bug-details.json
+        string=$(jq '.tweet' bug-details.json)
+        echo ${string:1:-1} >> tweets/${{ github.event.issue.number }}.tweet
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v3
+      with:
+        add-paths: |
+          tweets/${{ github.event.issue.number }}.tweet
+        commit-message: Add new tweet file via automation
+        title: 'New tweet request from ${{ github.event.issue.user.login }}'
+        body: |
+          This PR is auto-generated.
+          Fixes: #${{ github.event.issue.number }}
+        branch: add/${{ github.event.issue.number }}
+        base: main
+        signoff: true
+        delete-branch: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,15 +11,18 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+    # github-issue-parser parses issue and echo json output to tweet.json
     - name: Run Issue form parser
       uses: stefanbuck/github-issue-parser@v2
       id: issue-parser
       with:
-        template-path: .github/ISSUE_TEMPLATE/new-tweet-request.yaml
+        template-path: .github/ISSUE_TEMPLATE/new-tweet-request.yml
+    # parse tweet.json and echo the required data to .tweet file
     - run: |
-        echo '${{ steps.issue-parser.outputs.jsonString }}' > bug-details.json
-        string=$(jq '.tweet' bug-details.json)
+        echo '${{ steps.issue-parser.outputs.jsonString }}' > tweet.json
+        string=$(jq '.Tweet' tweet.json)
         echo ${string:1:-1} > tweets/${{ github.event.issue.number }}.tweet
+    # create-pull-request commits the .tweet file and opens a PR
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     - run: |
         echo '${{ steps.issue-parser.outputs.jsonString }}' > bug-details.json
         string=$(jq '.tweet' bug-details.json)
-        echo ${string:1:-1} >> tweets/${{ github.event.issue.number }}.tweet
+        echo ${string:1:-1} > tweets/${{ github.event.issue.number }}.tweet
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
       with:

--- a/.github/workflows/twitter-together.yml
+++ b/.github/workflows/twitter-together.yml
@@ -1,4 +1,4 @@
-on: [push]
+on: [push, pull_request]
 name: Twitter, together!
 jobs:
   preview:

--- a/.github/workflows/twitter-together.yml
+++ b/.github/workflows/twitter-together.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [push]
 name: Twitter, together!
 jobs:
   preview:


### PR DESCRIPTION
This workflow will automatically create a PR with a new `./tweets/*.tweet` file merging which should trigger already present twitter-together workflow and the tweet should go out.

I have tested this workflow on my own repo here: https://github.com/anubha-v-ardhan/test-twitter-together

The required issue form for this workflow will be added soon (see issue #16)


Fixes: #15
Thankyou :)