### PR TITLE
Correct `GITHUB_TOKEN` value in twitter-together.yml

### DIFF
--- a/.github/workflows/twitter-together.yml
+++ b/.github/workflows/twitter-together.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: gr2m/twitter-together@v1.x
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TOKEN_GITHUB }}
   tweet:
     name: Tweet
     runs-on: ubuntu-latest
@@ -19,7 +19,7 @@ jobs:
       - name: Tweet
         uses: gr2m/twitter-together@v1.x
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TOKEN_GITHUB }}
           TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
           TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
           TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}


### PR DESCRIPTION
This could be the reason why preview run is throwing auth failure. I remember we corrected this on #3 before merge but somehow it crept in